### PR TITLE
Various changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,5 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/neon64/chrome-native-messaging"
 
 [dependencies]
-byteorder = "1.3.4"
 serde_json = "1.0.61"
 serde = { version = "1.0.118", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,4 @@ repository = "https://github.com/neon64/chrome-native-messaging"
 [dependencies]
 byteorder = "1.3.4"
 serde_json = "1.0.61"
-thiserror = "1.0.23"
 serde = { version = "1.0.118", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use std::fmt::Display;
 macro_rules! send {
     ($($json:tt)+) => {{
         let v = json!($($json),+);
-        $crate::send_message(::std::io::stdout(), &v).unwrap();
+        $crate::send_message(::std::io::stdout(), &v)
     }}
 }
 
@@ -109,7 +109,8 @@ fn handle_panic(info: &std::panic::PanicInfo) {
             None => "Box<Any>",
         }
     };
-    send!({
+    // Ignore error if send fails, we don't want to panic inside the panic handler
+    let _ = send!({
         "status": "panic",
         "payload": msg,
         "file": info.location().map(|l| l.file()),
@@ -157,7 +158,7 @@ pub fn event_loop<T, E, F>(callback: F)
                     Ok(response) => send_message(io::stdout(), &response).unwrap(),
                     Err(e) => send!({
                         "error": format!("{}", e)
-                    })
+                    }).unwrap()
                 }
             }
             Err(e) => {
@@ -167,7 +168,7 @@ pub fn event_loop<T, E, F>(callback: F)
                 }
                 send!({
                     "error": format!("{}", e)
-                });
+                }).unwrap();
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ fn handle_panic(info: &std::panic::PanicInfo) {
 /// use chrome_native_messaging::event_loop;
 /// use std::io;
 /// use serde::Serialize;
-/// use serde_json::json;
+/// use serde_json::{json, Value};
 ///
 /// #[derive(Serialize)]
 /// struct BasicMessage<'a> {
@@ -137,7 +137,7 @@ fn handle_panic(info: &std::panic::PanicInfo) {
 /// }
 ///
 /// event_loop(|value| match value {
-///     Null => Err("null payload"),
+///     Value::Null => Err("null payload"),
 ///     _ => Ok(BasicMessage { payload: "Hello, World!" })
 /// });
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ use std::io::{Read, Write};
 use std::panic;
 use serde::Serialize;
 use serde_json::{json, Value};
-use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
 pub use crate::errors::Error;
 use std::fmt::Display;
 
@@ -25,7 +24,7 @@ use std::fmt::Display;
 macro_rules! send {
     ($($json:tt)+) => {{
         let v = json!($($json),+);
-        $crate::write_output(::std::io::stdout(), &v).unwrap();
+        $crate::send_message(::std::io::stdout(), &v).unwrap();
     }}
 }
 
@@ -46,7 +45,8 @@ macro_rules! send {
 ///     .err().expect("doctest should return unexpected eof");
 ///
 pub fn read_input<R: Read>(mut input: R) -> Result<Value, Error> {
-    match input.read_u32::<NativeEndian>() {
+    let mut buf = [0; 4];
+    match input.read_exact(&mut buf).map(|()| u32::from_ne_bytes(buf)) {
         Ok(length) => {
             //println!("Found length: {}", length);
             let mut buffer = vec![0; length as usize];
@@ -61,34 +61,6 @@ pub fn read_input<R: Read>(mut input: R) -> Result<Value, Error> {
             }
         }
     }
-}
-
-/// Writes an output to a stream, encoded according to
-/// Chrome's documentation on native messaging.
-/// (https://developer.chrome.com/extensions/nativeMessaging)
-///
-/// # Example
-///
-/// ```
-/// use chrome_native_messaging::write_output;
-/// use std::io;
-/// use serde_json::json;
-///
-/// let v = json!({ "msg": "Some other message" });
-/// write_output(io::stdout(), &v)
-///     .expect("failed to write to stdout");
-/// ```
-pub fn write_output<W: Write>(mut output: W, value: &Value) -> Result<(), Error> {
-    let msg = serde_json::to_string(value)?;
-    let len = msg.len();
-    // Chrome won't accept a message larger than 1MB
-    if len > 1024 * 1024 {
-        return Err(Error::MessageTooLarge { size: len });
-    }
-    output.write_u32::<NativeEndian>(len as u32)?;
-    output.write_all(msg.as_bytes())?;
-    output.flush()?;
-    Ok(())
 }
 
 /// Writes an output to a stream, encoded according to
@@ -119,7 +91,9 @@ pub fn send_message<W: Write, T: Serialize>(mut output: W, value: &T) -> Result<
     if len > 1024 * 1024 {
         return Err(Error::MessageTooLarge { size: len });
     }
-    output.write_u32::<NativeEndian>(len as u32)?;
+    let len = len as u32; // Cast is safe due to size check above
+    let len_bytes = len.to_ne_bytes();
+    output.write_all(&len_bytes)?;
     output.write_all(msg.as_bytes())?;
     output.flush()?;
     Ok(())

--- a/tests/test_payload_length.rs
+++ b/tests/test_payload_length.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use serde_json::json;
-use chrome_native_messaging::{write_output, Error};
+use chrome_native_messaging::{send_message, Error};
 use std::io::sink;
 
 #[derive(Serialize)]
@@ -22,7 +22,7 @@ fn test_payload_length() {
         "one_item": m
     });
 
-    assert!(write_output(sink(), &small_res).is_ok());
+    assert!(send_message(sink(), &small_res).is_ok());
 
     // this is almost 1024*1024 bytes long, but it should still work
     let list = std::iter::repeat(" ").take(1024*1024-20).collect::<String>();
@@ -30,7 +30,7 @@ fn test_payload_length() {
         "big_list": list
     });
 
-    assert!(write_output(sink(), &large_res).is_ok());
+    assert!(send_message(sink(), &large_res).is_ok());
 
     // this is almost 1024*1024 bytes long, but it should still work
     let list = std::iter::repeat(" ").take(1024*1024+20).collect::<String>();
@@ -38,7 +38,7 @@ fn test_payload_length() {
         "big_list": list
     });
 
-    match write_output(sink(), &too_large_res).err().expect("expected error") {
+    match send_message(sink(), &too_large_res).err().expect("expected error") {
         Error::MessageTooLarge { size: _ } => {},
         _ => panic!("expected `MessageTooLarge` error")
     }


### PR DESCRIPTION
I made some fairly bold changes to the code. I will understand if you don't want to merge them but figured I'd raise the PR for you to consider. The commits are pretty self-contained and do the following:

- Drop the `thiserror` dependency in favour of manually implementing the `std::error::Error` impl.
- Drop the `byteorder` dependency in favour of the functions in `std`.
- Fix a warning in some example code.
- Avoid unwrapping in the `send` macro:
  - This seemed like a bit of a footgun since the `unwrap` was hidden.
  - I used this change to potentially avoid re-panicking inside the panic handler.
- Drop the `write_output` method since `send_message` was identical.

I'd also like to run `rustfmt` on the code, if you're ok with that I'll do it in a separate PR.